### PR TITLE
[codex] Add site visitor counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Syifa Konveksi v2 adalah aplikasi katalog digital untuk menampilkan produk konve
 
 Production: https://www.syifakonveksi.my.id
 
+## Features
+
+- Public product catalog with category/search filtering.
+- Product detail view counter.
+- Site visitor counter for total visits and unique public IP visitors, shown in the admin dashboard.
+- Admin product management with category, color, stock status, and media controls.
+
 ## Tech Stack
 
 - Framework: Next.js 15 App Router
@@ -39,6 +46,8 @@ Create `.env` from `.env.example`, then set the required values.
 - `AUTH_SECRET`: required for production session signing.
 - `SEED_ADMIN_EMAIL`: seeded admin email.
 - `SEED_ADMIN_PASSWORD`: seeded admin password.
+
+After schema changes, run `npm run db:push` against the target database before deploying. The visitor dashboard metrics require the `site_visitors` table.
 
 ## Project Structure
 

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,6 +1,14 @@
 import Link from "next/link";
 import type React from "react";
-import { Boxes, Eye, PackageCheck, PlusCircle, TrendingUp } from "lucide-react";
+import {
+  Boxes,
+  Eye,
+  PackageCheck,
+  PlusCircle,
+  TrendingUp,
+  UserRoundCheck,
+  UsersRound,
+} from "lucide-react";
 
 import { AdminShell } from "@/components/admin-shell";
 import { Badge } from "@/components/ui/badge";
@@ -8,11 +16,12 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { listProducts } from "@/lib/product-service";
 import { formatRupiah } from "@/lib/utils";
+import { getSiteVisitorStats } from "@/lib/visitor-service";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminDashboardPage() {
-  const products = await listProducts();
+  const [products, visitorStats] = await Promise.all([listProducts(), getSiteVisitorStats()]);
   const totalViews = products.reduce((sum, product) => sum + product.views, 0);
   const totalValue = products.reduce((sum, product) => sum + product.harga, 0);
   const readyStock = products.filter((product) => product.stockStatus === "Ready").length;
@@ -35,7 +44,17 @@ export default async function AdminDashboardPage() {
         </Button>
       </div>
 
-      <div className="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+      <div className="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+        <Metric
+          icon={<UsersRound />}
+          label="Total pengunjung"
+          value={visitorStats.totalVisitors.toLocaleString("id-ID")}
+        />
+        <Metric
+          icon={<UserRoundCheck />}
+          label="Unique pengunjung"
+          value={visitorStats.uniqueVisitors.toLocaleString("id-ID")}
+        />
         <Metric icon={<Boxes />} label="Total produk" value={`${products.length}`} />
         <Metric icon={<Eye />} label="Total dilihat" value={totalViews.toLocaleString("id-ID")} />
         <Metric icon={<PackageCheck />} label="Ready stock" value={`${readyStock} produk`} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,16 @@
+import { headers } from "next/headers";
+
 import { CatalogPage } from "@/components/catalog-page";
 import { SiteHeader } from "@/components/site-header";
 import { listCategories, listProducts } from "@/lib/product-service";
+import { getPublicIpFromHeaders, recordSiteVisit } from "@/lib/visitor-service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
+  const requestHeaders = await headers();
+  await recordSiteVisit(getPublicIpFromHeaders(requestHeaders));
+
   const [products, categories] = await Promise.all([listProducts(), listCategories()]);
 
   return (

--- a/lib/visitor-service.ts
+++ b/lib/visitor-service.ts
@@ -1,0 +1,65 @@
+import { hasDatabaseUrl, prisma } from "@/lib/prisma";
+
+export type SiteVisitorStats = {
+  totalVisitors: number;
+  uniqueVisitors: number;
+};
+
+type HeaderReader = Pick<Headers, "get">;
+
+const IP_HEADERS = [
+  "x-forwarded-for",
+  "x-real-ip",
+  "cf-connecting-ip",
+  "true-client-ip",
+] as const;
+
+export function getPublicIpFromHeaders(headers: HeaderReader) {
+  for (const headerName of IP_HEADERS) {
+    const headerValue = headers.get(headerName);
+    const ipAddress = headerValue?.split(",")[0]?.trim();
+
+    if (ipAddress) {
+      return ipAddress;
+    }
+  }
+
+  return "unknown";
+}
+
+export async function recordSiteVisit(ipAddress: string) {
+  if (!hasDatabaseUrl()) {
+    return;
+  }
+
+  try {
+    await prisma.siteVisitor.upsert({
+      where: { ipAddress },
+      update: { visits: { increment: 1 } },
+      create: { ipAddress },
+    });
+  } catch (error) {
+    console.error("Unable to record site visit:", error);
+  }
+}
+
+export async function getSiteVisitorStats(): Promise<SiteVisitorStats> {
+  if (!hasDatabaseUrl()) {
+    return { totalVisitors: 0, uniqueVisitors: 0 };
+  }
+
+  try {
+    const [totalVisitors, uniqueVisitors] = await Promise.all([
+      prisma.siteVisitor.aggregate({ _sum: { visits: true } }),
+      prisma.siteVisitor.count(),
+    ]);
+
+    return {
+      totalVisitors: totalVisitors._sum.visits ?? 0,
+      uniqueVisitors,
+    };
+  } catch (error) {
+    console.error("Unable to load site visitor stats:", error);
+    return { totalVisitors: 0, uniqueVisitors: 0 };
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,3 +88,14 @@ model ProductColor {
   @@id([productId, colorId])
   @@map("product_colors")
 }
+
+model SiteVisitor {
+  id             String   @id @default(cuid())
+  ipAddress      String   @unique @map("ip_address")
+  visits         Int      @default(1)
+  firstVisitedAt DateTime @default(now()) @map("first_visited_at")
+  lastVisitedAt  DateTime @updatedAt @map("last_visited_at")
+
+  @@index([lastVisitedAt])
+  @@map("site_visitors")
+}

--- a/tests/visitor-counter.test.ts
+++ b/tests/visitor-counter.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getPublicIpFromHeaders, getSiteVisitorStats, recordSiteVisit } from "@/lib/visitor-service";
+
+function headers(values: Record<string, string | null>) {
+  return {
+    get(name: string) {
+      return values[name.toLowerCase()] ?? null;
+    },
+  };
+}
+
+test("getPublicIpFromHeaders prefers the first forwarded IP", () => {
+  assert.equal(
+    getPublicIpFromHeaders(headers({ "x-forwarded-for": "203.0.113.10, 10.0.0.1" })),
+    "203.0.113.10",
+  );
+});
+
+test("recordSiteVisit is a safe no-op without DATABASE_URL", async () => {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+  delete process.env.DATABASE_URL;
+
+  try {
+    await assert.doesNotReject(() => recordSiteVisit("203.0.113.10"));
+    assert.deepEqual(await getSiteVisitorStats(), { totalVisitors: 0, uniqueVisitors: 0 });
+  } finally {
+    if (originalDatabaseUrl) {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Adds site visitor analytics similar to the product detail view counter.

- records homepage visits by public IP header
- stores total visits per IP in `site_visitors`
- shows total visitors and unique visitors in the admin dashboard
- documents the feature and database push requirement in README

## Validation

- `npm test`
- `npm run build`
- `npm run db:push`
- `vercel deploy --prod --yes`
